### PR TITLE
using Addressable to avoid errors due to umlaut domains

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,18 @@ PATH
   remote: .
   specs:
     mida (0.3.6)
+      addressable (~> 2.3.6)
       blankslate (= 2.1.2.4)
       nokogiri (>= 1.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.3.6)
     blankslate (2.1.2.4)
     diff-lcs (1.1.3)
-    mini_portile (0.5.1)
-    nokogiri (1.6.0)
+    mini_portile (0.5.3)
+    nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
     rake (10.1.0)
     rspec (2.10.0)

--- a/lib/mida/datatype/url.rb
+++ b/lib/mida/datatype/url.rb
@@ -1,5 +1,7 @@
+#encoding: utf-8
 require 'mida/datatype/generic'
 require 'uri'
+require 'addressable/uri'
 
 module Mida
   module DataType
@@ -10,6 +12,7 @@ module Mida
 
       # Raises +ArgumentError+ if value not valid url
       def initialize(value)
+        value = ::Addressable::URI.encode(value)
         raise ::ArgumentError unless value =~ ::URI::DEFAULT_PARSER.regexp[:ABS_URI]
         @parsedValue = ::URI.parse(value)
       end

--- a/lib/mida/itemprop.rb
+++ b/lib/mida/itemprop.rb
@@ -1,6 +1,7 @@
 require 'nokogiri'
 require 'uri'
 require 'mida/itemscope'
+require 'addressable/uri'
 
 module Mida
 
@@ -52,6 +53,7 @@ module Mida
     # This returns an empty string if can't form a valid
     # absolute url as per the Microdata spec.
     def make_absolute_url(url)
+      url = ::Addressable::URI.encode(url)
       return url unless URI.parse(url).relative?
       begin
         URI.parse(@page_url).merge(url).to_s

--- a/mida.gemspec
+++ b/mida.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options << '--main' << 'README.rdoc'
   spec.add_dependency('blankslate', '2.1.2.4')
   spec.add_dependency('nokogiri', '>= 1.5')
+  spec.add_dependency('addressable', '~> 2.3.6')
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.10.0"

--- a/spec/datatype/url_spec.rb
+++ b/spec/datatype/url_spec.rb
@@ -1,3 +1,5 @@
+#encoding: utf-8
+#
 require 'mida/datatype'
 require 'yaml'
 
@@ -20,8 +22,9 @@ describe Mida::DataType::URL do
   end
 
 
-  it '#parse should accept a valid url' do
-    url_text = 'http://example.com/test/'
+  it '#parse should accept a valid url with special characters' do
+    url_text = 'http://example.com/übergangslösung'
     url = Mida::DataType::URL.parse(url_text)
+    url.to_s.should == ::Addressable::URI.encode(url_text)
   end
 end


### PR DESCRIPTION
This is a fix for the following issue I came across: parsing documents with anchors pointing to umlaut domains (non-ascii characters) caused errors.

You might also want to bump the version. Thank you for your time!
