### PR TITLE
Support creating mida documents from existing nokogiri documents

### DIFF
--- a/lib/mida/document.rb
+++ b/lib/mida/document.rb
@@ -16,7 +16,7 @@ module Mida
     # [page_url] The url of target used for form absolute urls. This must
     #            include the filename, e.g. index.html.
     def initialize(target, page_url=nil)
-      @doc = Nokogiri(target)
+      @doc = target.kind_of?(Nokogiri::XML::Document) ? target : Nokogiri(target)
       @page_url = page_url
       @items = extract_items
     end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -49,6 +49,8 @@ describe Mida::Document do
       </body></html>
     '
 
+    @nokogiri_document = Nokogiri(html)
+
     @md = Mida::Document.new(html)
   end
 
@@ -65,6 +67,11 @@ describe Mida::Document do
     organization = @md.find {|item| item.type == 'http://data-vocabulary.org/Organization'}
     organization.type.should == 'http://data-vocabulary.org/Organization'
     organization.properties['name'].should == ["An org name"]
+  end
+
+  it 'should not re-parse a nokogiri document' do
+    md = Mida::Document.new(@nokogiri_document)
+    md.instance_variable_get(:@doc).object_id.should == @nokogiri_document.object_id
   end
 end
 


### PR DESCRIPTION
It would be useful to be able to call Mida::Document#initialize with a nokogiri document in order to avoid having to re-parse html, for cases where the html has already been parsed elsewhere.