### PR TITLE
Use BasicObject instead of BlankSlate

### DIFF
--- a/lib/mida/datatype/enumeration.rb
+++ b/lib/mida/datatype/enumeration.rb
@@ -11,15 +11,13 @@ module Mida
     # [[DataType, Regexp], [DataType, Regexp]]
     class Enumeration < Generic
 
-      Enumeration.reveal(:class)
-
       # Raises +ArgumentError+ if value not valid value
       def initialize(value)
-        value_is_valid = self.class::VALID_VALUES.any? do |valid_value|
+        value_is_valid = (class << self; self end).superclass::VALID_VALUES.any? do |valid_value|
           @parsedValue = valid_value[0].parse(value)
           @parsedValue.to_s =~ valid_value[1]
         end
-        raise ArgumentError unless value_is_valid 
+        raise ::ArgumentError unless value_is_valid 
       end
 
     end

--- a/lib/mida/datatype/generic.rb
+++ b/lib/mida/datatype/generic.rb
@@ -1,10 +1,8 @@
-require 'blankslate'
-
 module Mida
   module DataType
 
     # The base DataType Parser
-    class Generic < BlankSlate
+    class Generic < BasicObject
       
       # Convenience method, same as +new+
       def self.parse(value)

--- a/lib/mida/datatype/iso8601date.rb
+++ b/lib/mida/datatype/iso8601date.rb
@@ -12,7 +12,7 @@ module Mida
       def initialize(value)
         @parsedValue = ::DateTime.iso8601(value)
       rescue => e
-        raise ArgumentError, e
+        raise ::ArgumentError, e
       end
 
       def to_s

--- a/mida.gemspec
+++ b/mida.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extra_rdoc_files = ['README.rdoc', 'LICENCE.rdoc', 'CHANGELOG.rdoc']
   spec.rdoc_options << '--main' << 'README.rdoc'
-  spec.add_dependency('blankslate', '3.1.3')
   spec.add_dependency('nokogiri', '>= 1.6')
   spec.add_dependency('addressable', '~> 2.3.8')
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Not sure if this is of interest but it's possible to eliminate the blankslate dependency by using Ruby's built-in BasicObject class instead.