### PR TITLE
Fix cli https error

### DIFF
--- a/bin/mida
+++ b/bin/mida
@@ -71,7 +71,7 @@ end
 
 # Get the url from the source if there is one
 def get_url
-  ARGV.first =~ %r{^http://.*} ? ARGV.first : nil
+  ARGV.first =~ %r{^http[s]://.*} ? ARGV.first : nil
 end
 
 # Display each item as yaml

--- a/bin/mida
+++ b/bin/mida
@@ -71,7 +71,7 @@ end
 
 # Get the url from the source if there is one
 def get_url
-  ARGV.first =~ %r{^http[s]://.*} ? ARGV.first : nil
+  ARGV.first =~ %r{^https?://.*} ? ARGV.first : nil
 end
 
 # Display each item as yaml

--- a/lib/mida/document.rb
+++ b/lib/mida/document.rb
@@ -14,7 +14,9 @@ module Mida
     #
     # [target] The string containing the html that you want to parse.
     # [page_url] The url of target used for form absolute urls. This must
-    #            include the filename, e.g. index.html.
+    #            include the filename, e.g. index.html. If page_url is nil or
+    #            invalid, properties with a relative url will be parsed as an
+    #            empty string.
     def initialize(target, page_url=nil)
       @doc = target.kind_of?(Nokogiri::XML::Document) ? target : Nokogiri(target)
       @page_url = page_url


### PR DESCRIPTION
This is related to #20.

The command line tool for mida doesn't correctly parse https urls, resulting in the failure to create an absolute url for images. This pr fixes the issue with the cli tool.

In issue #20 I had the same problem because I didn't pass a page url to `Document.new`, and no error is raised. Instead, `Itemprop.make_absolute_url` just returns an empty string.

That's by design, but it was certainly hard for me to track down, so I've updated the comment for `Document.new`.